### PR TITLE
Removed input clear when displaying a message.

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -38,7 +38,6 @@ function displayMessage(message, classStyle, time, id, name) {
         '</li>';
         
         $("#messageList").append(messageItem);
-        $("#message").val("");
         $("#messageContainer").scrollTop($("#messageContainer").prop("scrollHeight"));
     }
 }


### PR DESCRIPTION
Removed the message input clear when displaying a message. The input clearing only happens when a user sends a message.